### PR TITLE
feat: Implement .env support for API key management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,111 @@
+# Environments - IMPORTANT: Ensure .env is ignored for security
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+# Usually these files are written by a PyInstaller script; adding them
+# here helps ensure they're not accidentally committed.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.log
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+# *.log # Note: .log is already listed under unit test/coverage, be mindful of duplicates if merging
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# PEP 582; __pypackages__ directory
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# IDE / Editor specific files
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -67,24 +67,22 @@ This application leverages the power of OpenAI's Large Language Models (LLMs), s
 
 ## Configuration
 
-1.  **Set the OpenAI API Key:**
-    The application requires an OpenAI API key to interact with the LLMs. Set this key as an environment variable.
-    *   On Linux/macOS:
+1.  **Set up OpenAI API Key:**
+    *   This project uses an `.env` file to manage the OpenAI API key, leveraging the `python-dotenv` library. This is the recommended way to handle your API key securely.
+    *   An example file `.env.example` is provided. Copy it to create your own `.env` file:
         ```bash
-        export OPENAI_API_KEY='your_api_key_here'
+        cp .env.example .env
         ```
-    *   On Windows (Command Prompt):
-        ```bash
-        set OPENAI_API_KEY=your_api_key_here
+    *   Open the newly created `.env` file (e.g., with a text editor) and add your actual OpenAI API key:
+        ```env
+        OPENAI_API_KEY="your_actual_api_key_here" 
         ```
-    *   On Windows (PowerShell):
-        ```powershell
-        $env:OPENAI_API_KEY='your_api_key_here'
-        ```
-    Replace `'your_api_key_here'` with your actual OpenAI API key.
+        Replace `"your_actual_api_key_here"` with your real API key.
+    *   **Important:** The `.env` file contains sensitive information and is included in `.gitignore` to prevent accidental commits. Do not remove it from `.gitignore`.
+    *   (Alternative) While using a `.env` file is preferred, the application will still respect the `OPENAI_API_KEY` if it's set directly as an environment variable in your system (e.g., via `export` or `set`). However, the `.env` method takes precedence if the file exists and the variable is set within it, due to the `load_dotenv()` call in `app.py`.
 
-2.  **OpenAI Account & Models:**
-    Ensure your OpenAI account associated with the API key has sufficient credits and access to the `gpt-3.5-turbo` and `gpt-4o` models.
+2.  **Ensure API Access (OpenAI Account & Models):**
+    Make sure your OpenAI account associated with the API key has sufficient credits and access to the `gpt-3.5-turbo` and `gpt-4o` models.
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ scikit-learn
 numpy
 openai
 scipy
+python-dotenv
 # Add other dependencies here, one per line
 # For example:
 # pandas

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,15 +27,42 @@ class TestAppFlow(unittest.TestCase):
 
         self.temp_data_dir_name = "temp_integration_project_data"
         self.temp_data_dir = current_dir / self.temp_data_dir_name
-        
         self._setup_project_data_dir() # Creates an empty dir
 
-        # Store and set a dummy API key for most tests
-        self.original_api_key = os.environ.get("OPENAI_API_KEY")
-        self.original_app_api_key_value = current_app_module.OPENAI_API_KEY_VALUE
-        os.environ["OPENAI_API_KEY"] = "test_dummy_key"
-        current_app_module.OPENAI_API_KEY_VALUE = "test_dummy_key"
+        # Store original API key state
+        self.original_env_api_key = os.environ.get("OPENAI_API_KEY")
+        self.original_app_module_api_key_value = current_app_module.OPENAI_API_KEY_VALUE
+        
+        # .env file path for tests (project root)
+        self.dotenv_path = project_root / ".env"
+        self.original_dotenv_exists = self.dotenv_path.exists()
+        self.original_dotenv_content = ""
+        if self.original_dotenv_exists:
+            with open(self.dotenv_path, "r") as f:
+                self.original_dotenv_content = f.read()
+        
+        # Ensure a clean state for os.environ regarding the key for each test, if needed by test.
+        # Tests themselves will now be responsible for setting os.environ["OPENAI_API_KEY"]
+        # or current_app_module.OPENAI_API_KEY_VALUE as per their specific scenario.
+        if "OPENAI_API_KEY" in os.environ:
+            del os.environ["OPENAI_API_KEY"]
+        current_app_module.OPENAI_API_KEY_VALUE = None
 
+
+    def _create_env_file(self, content: str):
+        # Clean up if a .env file from a previous test (or user) exists
+        if self.dotenv_path.exists():
+            self.dotenv_path.unlink()
+        with open(self.dotenv_path, "w") as f:
+            f.write(content)
+
+    def _remove_env_file(self):
+        if self.dotenv_path.exists():
+            self.dotenv_path.unlink()
+        # Restore original .env if it existed
+        if self.original_dotenv_exists:
+            with open(self.dotenv_path, "w") as f:
+                f.write(self.original_dotenv_content)
 
     def _setup_project_data_dir(self, docs_content: dict = None):
         if self.temp_data_dir.exists():
@@ -63,11 +90,14 @@ class TestAppFlow(unittest.TestCase):
         self.project_data_dir_patcher.stop()
 
         # Restore original API key
-        if self.original_api_key is None:
-            del os.environ["OPENAI_API_KEY"]
+        if self.original_env_api_key is None:
+            if "OPENAI_API_KEY" in os.environ: # if test set it
+                del os.environ["OPENAI_API_KEY"]
         else:
-            os.environ["OPENAI_API_KEY"] = self.original_api_key
-        current_app_module.OPENAI_API_KEY_VALUE = self.original_app_api_key_value
+            os.environ["OPENAI_API_KEY"] = self.original_env_api_key
+        
+        current_app_module.OPENAI_API_KEY_VALUE = self.original_app_module_api_key_value
+        self._remove_env_file() # Clean up any test .env and restore original if existed
         
         # Remove project root from sys.path if it was added
         if str(project_root) in sys.path:
@@ -103,8 +133,79 @@ class TestAppFlow(unittest.TestCase):
         self.assertIn("Refined: Awesome Python expert Jane Doe, 7 years cloud experience, needed now!", output)
         self.assertIn("Retrieved RAG context", output)
 
+    @patch('app.sys.exit') # Mock sys.exit to prevent test termination
+    @patch('app.retrieve_relevant_chunk', MagicMock(return_value="dummy rag context")) # Mock RAG
+    @patch('app.call_openai_api')
+    def test_api_key_loaded_from_dotenv_file(self, mock_call_openai_api: MagicMock, mock_sys_exit: MagicMock):
+        # Ensure os.environ is clean for this key
+        if "OPENAI_API_KEY" in os.environ:
+            del os.environ["OPENAI_API_KEY"]
+        current_app_module.OPENAI_API_KEY_VALUE = None # Reflect that it's not in env at app import
+
+        self._create_env_file('OPENAI_API_KEY="key_from_test_dotenv"')
+        
+        mock_call_openai_api.side_effect = ["Draft from .env", "Refined from .env"]
+        main()
+        
+        self.assertEqual(current_app_module.OPENAI_API_KEY_VALUE, "key_from_test_dotenv")
+        mock_sys_exit.assert_not_called() # Should not exit if key is found
+        self.assertEqual(mock_call_openai_api.call_count, 2)
+        output = self.captured_stdout.getvalue()
+        self.assertIn("Refined from .env", output)
+
+    @patch('app.sys.exit')
+    @patch('app.retrieve_relevant_chunk', MagicMock(return_value="dummy rag context"))
+    @patch('app.call_openai_api')
+    def test_dotenv_does_not_override_existing_env_variable(self, mock_call_openai_api: MagicMock, mock_sys_exit: MagicMock):
+        # Set key in os.environ BEFORE main() and .env creation
+        os.environ["OPENAI_API_KEY"] = "key_from_os_environ"
+        # This simulates app.py's global OPENAI_API_KEY_VALUE being set at import time
+        current_app_module.OPENAI_API_KEY_VALUE = "key_from_os_environ" 
+
+        self._create_env_file('OPENAI_API_KEY="key_from_test_dotenv_should_be_ignored"')
+        
+        mock_call_openai_api.side_effect = ["Draft from os_environ", "Refined from os_environ"]
+        main()
+
+        # python-dotenv by default does NOT override existing environment variables.
+        # The app.py logic also updates global OPENAI_API_KEY_VALUE based on os.getenv after load_dotenv.
+        self.assertEqual(current_app_module.OPENAI_API_KEY_VALUE, "key_from_os_environ")
+        mock_sys_exit.assert_not_called()
+        self.assertEqual(mock_call_openai_api.call_count, 2)
+        output = self.captured_stdout.getvalue()
+        self.assertIn("Refined from os_environ", output)
+
+    @patch('app.sys.exit')
+    @patch('app.retrieve_relevant_chunk', MagicMock(return_value="dummy rag context"))
+    @patch('app.call_openai_api')
+    def test_api_key_loaded_from_dotenv_if_not_in_os_environ(self, mock_call_openai_api: MagicMock, mock_sys_exit: MagicMock):
+        # Explicitly ensure OPENAI_API_KEY is not in os.environ
+        if "OPENAI_API_KEY" in os.environ:
+            del os.environ["OPENAI_API_KEY"]
+        # Simulate that the global key was None at import time
+        current_app_module.OPENAI_API_KEY_VALUE = None
+
+        self._create_env_file('OPENAI_API_KEY="key_from_dotenv_when_os_empty"')
+        
+        mock_call_openai_api.side_effect = ["Draft from .env (os empty)", "Refined from .env (os empty)"]
+        main()
+
+        self.assertEqual(current_app_module.OPENAI_API_KEY_VALUE, "key_from_dotenv_when_os_empty")
+        mock_sys_exit.assert_not_called()
+        self.assertEqual(mock_call_openai_api.call_count, 2)
+        output = self.captured_stdout.getvalue()
+        self.assertIn("Refined from .env (os empty)", output)
+
+
     @patch('app.call_openai_api')
     def test_rag_finds_no_relevant_documents(self, mock_call_openai_api: MagicMock):
+        # This test might need OPENAI_API_KEY to be set to avoid sys.exit
+        # For simplicity, let's ensure it's set (e.g. by .env or os.environ)
+        # The focus here is RAG, not API key loading.
+        # We can use the .env creation for a default valid key.
+        self._create_env_file('OPENAI_API_KEY="dummy_key_for_rag_test"')
+        current_app_module.OPENAI_API_KEY_VALUE = None # Ensure it's loaded by main
+
         self._setup_project_data_dir({"internal_memo.txt": "Company holiday party next week."})
         
         mock_call_openai_api.side_effect = [
@@ -127,6 +228,9 @@ class TestAppFlow(unittest.TestCase):
 
     @patch('app.call_openai_api')
     def test_no_documents_in_project_data(self, mock_call_openai_api: MagicMock):
+        self._create_env_file('OPENAI_API_KEY="dummy_key_for_nodoc_test"')
+        current_app_module.OPENAI_API_KEY_VALUE = None
+
         self._setup_project_data_dir() # Empty
         
         mock_call_openai_api.side_effect = [
@@ -167,6 +271,9 @@ class TestAppFlow(unittest.TestCase):
 
     @patch('app.call_openai_api')
     def test_llm_draft_fails(self, mock_call_openai_api: MagicMock):
+        self._create_env_file('OPENAI_API_KEY="dummy_key_for_draftfail_test"')
+        current_app_module.OPENAI_API_KEY_VALUE = None
+
         self._setup_project_data_dir() # Empty
         
         mock_call_openai_api.return_value = "" # Simulate first call (draft) failing
@@ -181,6 +288,9 @@ class TestAppFlow(unittest.TestCase):
 
     @patch('app.call_openai_api')
     def test_llm_refinement_fails(self, mock_call_openai_api: MagicMock):
+        self._create_env_file('OPENAI_API_KEY="dummy_key_for_refinefail_test"')
+        current_app_module.OPENAI_API_KEY_VALUE = None
+
         self._setup_project_data_dir() # Empty
         
         mock_call_openai_api.side_effect = [


### PR DESCRIPTION
This commit introduces support for managing the OPENAI_API_KEY using a .env file.

Changes include:
- Added `python-dotenv` to project dependencies.
- Modified `app.py` to call `load_dotenv()` on startup, allowing OPENAI_API_KEY to be loaded from a `.env` file.
- Updated the error message for missing API key to mention the .env file.
- Added `.env` to `.gitignore` to prevent accidental commits of your credentials.
- Included common Python patterns in `.gitignore`.
- Created an `.env.example` file to serve as a template for you.
- Updated `README.md` to instruct you on setting up your API key via the .env file.
- Added new unit tests in `tests/test_app.py` to verify:
    - API key is loaded from `.env` if not set in OS environment.
    - OS environment variable for API key takes precedence over `.env` file.
- Existing tests were updated to correctly manage API key state with the new loading mechanism.